### PR TITLE
Fix: Primary menu expansion

### DIFF
--- a/config/optional/block.block.cds_design_system_menu_primary.yml
+++ b/config/optional/block.block.cds_design_system_menu_primary.yml
@@ -27,5 +27,5 @@ settings:
     group: '@domain_group.domain_group_context:group'
   level: 1
   depth: 0
-  expand_all_items: true
+  expand_all_items: false
 visibility: {}


### PR DESCRIPTION
The Primary menu should not be expanded by default.  This allows Editors to decide which menu items to expand.