### PR TITLE
Chore: Drupal core compatibility

### DIFF
--- a/cds_design_system.info.yml
+++ b/cds_design_system.info.yml
@@ -1,7 +1,7 @@
 name: Design and content guidelines
 description: Design and content guidelines (AKA Style guide) configuration.
 type: module
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ">=9"
 
 dependencies:
   - drupal:taxonomy


### PR DESCRIPTION
Rather than restricting this module to Drupal 8-10, choosing a looser version requirement specifying anything above Drupal 9.