### PR TITLE
Fix: Drupal 10 compatible condition

### DIFF
--- a/config/optional/pathauto.pattern.cds_design_system.yml
+++ b/config/optional/pathauto.pattern.cds_design_system.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '[node:menu-link:parents:join-path]/[node:title]'
 selection_criteria:
   e5e7230f-9f07-4108-b829-34cd3a139cfd:
-    id: node_type
+    id: 'entity_bundle:node'
     bundles:
       cds_design_system: cds_design_system
     negate: false


### PR DESCRIPTION
The selection criteria for automatic URL alias creation of Design system pages has become outdated in Drupal 10.  This fix ensures Drupal 10 compatibility.